### PR TITLE
Various fixes for parameter encoding

### DIFF
--- a/Classes/OAMutableURLRequest.m
+++ b/Classes/OAMutableURLRequest.m
@@ -132,7 +132,7 @@ signatureProvider:(id<OASignatureProviding>)aProvider
     //NSMakeCollectable(theUUID);
 	if (nonce) {
 	}
-    nonce = (__bridge NSString *)string;
+    nonce = CFBridgingRelease(string);
 }
 
 NSInteger normalize(id obj1, id obj2, void *context)
@@ -180,11 +180,9 @@ NSInteger normalize(id obj1, id obj2, void *context)
 		[parameterPairs addObject:[[OARequestParameter requestParameter:k value:[tokenParameters objectForKey:k]] URLEncodedNameValuePair]];
 	}
     
-	if (![[self valueForHTTPHeaderField:@"Content-Type"] hasPrefix:@"multipart/form-data"]) {
-		for (OARequestParameter *param in parameters) {
-			[parameterPairs addObject:[param URLEncodedNameValuePair]];
-		}
-	}
+    for (OARequestParameter *param in parameters) {
+        [parameterPairs addObject:[param URLEncodedNameValuePair]];
+    }
     
     // Oauth Spec, Section 3.4.1.3.2 "Parameters Normalization    
     NSArray *sortedPairs = [parameterPairs sortedArrayUsingFunction:normalize context:NULL];

--- a/OAuthConsumer.podspec
+++ b/OAuthConsumer.podspec
@@ -9,7 +9,7 @@
 
 Pod::Spec.new do |s|
   s.name             = "OAuthConsumer"
-  s.version          = "1.0.6"
+  s.version          = "1.0.7"
   s.summary          = "OAuthConsumer is an iPhone-ready iOS 8.0 compatible, ARC-supported OAuth implementation."
   s.homepage         = "https://github.com/lborsato/oAuthConsumer-pod"
   s.license          = 'MIT'

--- a/OAuthConsumer.podspec
+++ b/OAuthConsumer.podspec
@@ -9,56 +9,12 @@
 
 Pod::Spec.new do |s|
   s.name             = "OAuthConsumer"
-  s.version          = "1.0.3"
+  s.version          = "1.0.6"
   s.summary          = "OAuthConsumer is an iPhone-ready iOS 8.0 compatible, ARC-supported OAuth implementation."
-  s.description      = <<-DESC
-#OAuthConsumer
-
-
-This is an iPhone ready version of:
-http://oauth.googlecode.com/svn/code/obj-c/OAuthConsumer by Jon Crosby.
-
-This version has been updated for iOS 8.0 and to use Automatic Reference Counting (ARC). You will need to add **Security.framework**.
-
-"iPhone ready" simply means you just need to add the files to Xcode, and import "OAuthConsumer.h".
-
-OADataFetcher now also includes the ability to use blocks in addition to delegates as seen in this example:
-
-	OAConsumer *consumer = [[OAConsumer alloc] initWithKey:self.consumerKey secret:self.consumerSecret];
-	OAToken *token = [[OAToken alloc] initWithKey:self.accessToken secret:self.accessTokenSecret];
-	NSURL* url = [NSURL URLWithString:urlString];
-	OAMutableURLRequest* request = [[OAMutableURLRequest alloc] initWithURL:url consumer:consumer token:token realm:nil signatureProvider:nil];
-	[request setHTTPMethod:@"POST"];
-	NSMutableArray *params = [[NSMutableArray alloc] init];
-	for ( NSString *key in [postParams allKeys] )
-	{
-		OARequestParameter* param = [[OARequestParameter alloc] initWithName:key value:postParams[key]];
-		[params addObject:param];
-	}
-	if ( [params count] > 0 )
-		[request setParameters:params];
-	OADataFetcher* dataFetcher = [[OADataFetcher alloc] init];
-	[dataFetcher performRequest:request
-					withHandler:^(OAServiceTicket *ticket, NSData *data, NSError *error) {
-				   if ( !error ) {
-					   NSLog(@"didPost:=%@", [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding]);
-					   [self updateStatusCompleteWithStatus:SCUpdateSuccessful data:data error:nil];
-				   }
-				   else
-				   {
-					   [self updateStatusCompleteWithStatus:SCUpdateFailed data:data error:error];
-				   }
-			   }];
-
-
-This is a work in progress. Please feel free to contact me at larry [at] larryborsato [dot] com.
-                       DESC
   s.homepage         = "https://github.com/lborsato/oAuthConsumer-pod"
-  # s.screenshots     = "www.example.com/screenshots_1", "www.example.com/screenshots_2"
   s.license          = 'MIT'
-  s.author           = { "Larry Borsato" => "larry@larryborsato.com" }
-  s.source           = { :git => "https://github.com/lborsato/oAuthConsumer-pod.git", :tag => s.version.to_s }
-  s.social_media_url = 'https://twitter.com/lborsato'
+  s.author           = { "Larry Borsato" => "larry@larryborsato.com", "Shen Lu" => "lushen124@gmail.com" }
+  s.source           = { :git => "git@github.com:lushen124/oAuthConsumer-pod.git", :tag => s.version.to_s }
 
   s.platform     = :ios, '7.0'
   s.requires_arc = true
@@ -67,8 +23,4 @@ This is a work in progress. Please feel free to contact me at larry [at] larrybo
   s.resource_bundles = {
     'OAuthConsumer' => ['Pod/Assets/*.png']
   }
-
-  # s.public_header_files = 'Pod/Classes/**/*.h'
-  # s.frameworks = 'UIKit', 'MapKit'
-  # s.dependency 'AFNetworking', '~> 2.3'
 end


### PR DESCRIPTION
- Minor fixes to determining proper parameters for encoding and support for PUT and DELETE query params to be encoded.
- Plugged a memory leak with the nonce.
- Remove code to inhibit parameter encoding when using multi-part form data (they can still have query parameters that need to be encoded).
