### PR TITLE
Various fixes for parameter encoding

### DIFF
--- a/Classes/OAMutableURLRequest.m
+++ b/Classes/OAMutableURLRequest.m
@@ -132,7 +132,7 @@ signatureProvider:(id<OASignatureProviding>)aProvider
     //NSMakeCollectable(theUUID);
 	if (nonce) {
 	}
-    nonce = (__bridge NSString *)string;
+    nonce = CFBridgingRelease(string);
 }
 
 NSInteger normalize(id obj1, id obj2, void *context)
@@ -180,11 +180,9 @@ NSInteger normalize(id obj1, id obj2, void *context)
 		[parameterPairs addObject:[[OARequestParameter requestParameter:k value:[tokenParameters objectForKey:k]] URLEncodedNameValuePair]];
 	}
     
-	if (![[self valueForHTTPHeaderField:@"Content-Type"] hasPrefix:@"multipart/form-data"]) {
-		for (OARequestParameter *param in parameters) {
-			[parameterPairs addObject:[param URLEncodedNameValuePair]];
-		}
-	}
+    for (OARequestParameter *param in parameters) {
+        [parameterPairs addObject:[param URLEncodedNameValuePair]];
+    }
     
     // Oauth Spec, Section 3.4.1.3.2 "Parameters Normalization    
     NSArray *sortedPairs = [parameterPairs sortedArrayUsingFunction:normalize context:NULL];


### PR DESCRIPTION
- Minor fixes to determining proper parameters for encoding and support for PUT and DELETE query params to be encoded.
- Plugged a memory leak with the nonce.
- Remove code to inhibit parameter encoding when using multi-part form data (they can still have query parameters that need to be encoded).
